### PR TITLE
Also remove final classes when running composer install/update

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,5 +20,6 @@ When does this plugin update EasyAdmin classes?
 
 * Just after installing this Composer plugin;
 * Just after installing or updating any EasyAdmin version.
+* Just after running `composer update` or `composer install` commands.
 
 [1]: https://easycorp.github.io/blog/posts/the-road-to-easyadmin-3-no-more-inheritance

--- a/src/NoFinalClassPlugin.php
+++ b/src/NoFinalClassPlugin.php
@@ -12,6 +12,8 @@ use Composer\Installer\PackageEvents;
 use Composer\IO\IOInterface;
 use Composer\Package\PackageInterface;
 use Composer\Plugin\PluginInterface;
+use Composer\Script\Event;
+use Composer\Script\ScriptEvents;
 
 final class NoFinalClassPlugin implements PluginInterface, EventSubscriberInterface
 {
@@ -27,6 +29,8 @@ final class NoFinalClassPlugin implements PluginInterface, EventSubscriberInterf
         return [
             PackageEvents::POST_PACKAGE_INSTALL => 'onPackageInstall',
             PackageEvents::POST_PACKAGE_UPDATE => 'onPackageUpdate',
+            ScriptEvents::POST_INSTALL_CMD => 'onInstallCmd',
+            ScriptEvents::POST_UPDATE_CMD => 'onUpdateCmd',
         ];
     }
 
@@ -53,6 +57,16 @@ final class NoFinalClassPlugin implements PluginInterface, EventSubscriberInterf
             return;
         }
 
+        $this->removeFinalFromAllEasyAdminClasses();
+    }
+
+    public function onInstallCmd(Event $event)
+    {
+        $this->removeFinalFromAllEasyAdminClasses();
+    }
+
+    public function onUpdateCmd(Event $event)
+    {
         $this->removeFinalFromAllEasyAdminClasses();
     }
 


### PR DESCRIPTION
With this change, `final` is also removed when running `composer install` and `composer update`.

This fixes:
- https://github.com/EasyCorp/easyadmin-no-final-plugin/issues/2
- https://github.com/EasyCorp/easyadmin-no-final-plugin/issues/3